### PR TITLE
Solved error with encode

### DIFF
--- a/lib/JSOG.js
+++ b/lib/JSOG.js
@@ -48,7 +48,7 @@
           _results = [];
           for (_i = 0, _len = original.length; _i < _len; _i++) {
             val = original[_i];
-            _results.push(encode(val));
+            _results.push(JSOG.encode(val));
           }
           return _results;
         })();


### PR DESCRIPTION
Solved error with encode. "enconde" was outside the scope of the function.
