### PR TITLE
don't leave __jsogObjectId in originals after doEncode

### DIFF
--- a/lib/JSOG.js
+++ b/lib/JSOG.js
@@ -7,13 +7,18 @@
   nextId = 1;
 
   JSOG.encode = function(original) {
-    var doEncode, idOf, sofar;
+    var cleanup, doEncode, encoded, idOf, originals, sofar;
     sofar = {};
+    originals = [];
     idOf = function(obj) {
       if (!obj.__jsogObjectId) {
         obj.__jsogObjectId = "" + (nextId++);
+        originals.push(obj);
       }
       return obj.__jsogObjectId;
+    };
+    cleanup = function(original) {
+      return delete original.__jsogObjectId;
     };
     doEncode = function(original) {
       var encodeArray, encodeObject;
@@ -58,7 +63,9 @@
         return original;
       }
     };
-    return doEncode(original);
+    encoded = doEncode(original);
+    originals.forEach(cleanup);
+    return encoded;
   };
 
   JSOG.decode = function(encoded) {

--- a/src/JSOG.coffee
+++ b/src/JSOG.coffee
@@ -19,12 +19,18 @@ JSOG.encode = (original) ->
 
 	sofar = {}
 
+	originals = []
+
 	# Get (and if necessary, set) an object id. This ends up being left behind in the original object.
 	idOf = (obj) ->
 		if !obj.__jsogObjectId
 			obj.__jsogObjectId = "#{nextId++}"
+			originals.push obj
 
 		return obj.__jsogObjectId
+
+	cleanup = (original) ->
+		delete original.__jsogObjectId
 
 	doEncode = (original) ->
 		encodeObject = (original) ->
@@ -51,7 +57,9 @@ JSOG.encode = (original) ->
 		else
 			return original
 
-	return doEncode(original)
+	encoded= doEncode(original)
+	originals.forEach cleanup
+	return encoded;
 
 #
 # Take a JSOG-encoded JSON structure and re-link all the references. The return value will


### PR DESCRIPTION
Removes __jsogObjectId from originals before returning the encoded result.
