### PR TITLE
Pass `space` and `replacer` parameters to `JSON.stringify()`

### DIFF
--- a/lib/JSOG.js
+++ b/lib/JSOG.js
@@ -146,8 +146,8 @@
     return doDecode(encoded);
   };
 
-  JSOG.stringify = function(obj) {
-    return JSON.stringify(JSOG.encode(obj));
+  JSOG.stringify = function(obj, replacer, space) {
+    return JSON.stringify(JSOG.encode(obj, replacer, space));
   };
 
   JSOG.parse = function(str, revive) {

--- a/lib/JSOG.js
+++ b/lib/JSOG.js
@@ -133,6 +133,8 @@
       };
       if (encoded == null) {
         return encoded;
+      } else if (encoded instanceof Date) { 
+        return encoded;
       } else if (isArray(encoded)) {
         return decodeArray(encoded);
       } else if (typeof encoded === 'object') {
@@ -148,8 +150,8 @@
     return JSON.stringify(JSOG.encode(obj));
   };
 
-  JSOG.parse = function(str) {
-    return JSOG.decode(JSON.parse(str));
+  JSOG.parse = function(str, revive) {
+    return JSOG.decode(JSON.parse(str, revive));
   };
 
   if ((typeof module !== "undefined" && module !== null) && module.exports) {

--- a/lib/JSOG.js
+++ b/lib/JSOG.js
@@ -147,7 +147,7 @@
   };
 
   JSOG.stringify = function(obj, replacer, space) {
-    return JSON.stringify(JSOG.encode(obj, replacer, space));
+    return JSON.stringify(JSOG.encode(obj), replacer, space);
   };
 
   JSOG.parse = function(str, revive) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsog",
-  "version": "1.1.2-stringify",
+  "version": "1.1.2-stringify-params",
   "main": "lib/JSOG",
   "devDependencies": {
     "coffee-script": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsog",
-  "version": "1.1.0",
+  "version": "1.1.1-datefix",
   "main": "lib/JSOG",
   "devDependencies": {
     "coffee-script": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsog",
-  "version": "1.1.1-datefix",
+  "version": "1.1.2-stringify",
   "main": "lib/JSOG",
   "devDependencies": {
     "coffee-script": "^1.10.0",


### PR DESCRIPTION
Pass the additional parameters of [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) to have them supported in `JSOG` as well.